### PR TITLE
feat: Better package logging. ...

### DIFF
--- a/om-logging.cabal
+++ b/om-logging.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                om-logging
-version:             1.0.0.1
+version:             1.0.0.2
 synopsis:            Opinionated logging utilities.
 description:         Opinionated logging utilities.
 homepage:            https://github.com/owensmurray/om-logging

--- a/om-logging.cabal
+++ b/om-logging.cabal
@@ -28,6 +28,7 @@ library
     fast-logger  >= 3.0.5     && < 3.1,
     monad-logger >= 0.3.36    && < 0.4,
     om-show      >= 0.1.1.3   && < 0.2,
+    split        >= 0.2.3.4   && < 0.3,
     text         >= 1.2.4.1   && < 1.3,
     time         >= 1.9.3     && < 1.10
   hs-source-dirs:      src

--- a/src/OM/Logging.hs
+++ b/src/OM/Logging.hs
@@ -31,6 +31,8 @@ import Control.Monad (when)
 import Control.Monad.Logger (LogLevel(LevelDebug, LevelError, LevelInfo,
   LevelOther, LevelWarn), Loc, LogSource, LogStr, loc_package)
 import Data.Aeson (FromJSON(parseJSON), Value(String))
+import Data.List (intercalate)
+import Data.List.Split (splitOn)
 import Data.String (IsString)
 import Data.Text (Text)
 import Data.Time (getCurrentTime)
@@ -126,7 +128,25 @@ withPackage
   -> LogStr
   -> IO ()
 withPackage base loc src level msg =
-  let package = toLogStr . squareBracket . loc_package $ loc
+  let
+    {-
+      The package information looks like this
+      `om-legion-6.4.1.1-LnoDD8xLijN7DglolZGFIp`, but we only want the
+      actual package name, which is why we do the `reverse . split`
+      business.
+    -}
+    package =
+      toLogStr
+      . squareBracket
+      $ case
+          reverse
+          . splitOn "-"
+          . loc_package
+          $ loc
+        of
+          _hash : _version : nameComponents ->
+            intercalate "-" (reverse nameComponents)
+          _ -> loc_package loc
   in base loc src level (package <> msg)
 
 


### PR DESCRIPTION
This change strips off the package hash suffix that is generally
appended to the real package name.

i.e. s/om-legion-6.4.1.1-LnoDD8xLijN7DglolZGFIp/om-legion-6.4.1.1